### PR TITLE
fix: switch to std::nullptr_t, add release-mode defined behavior

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -18,6 +18,7 @@ std::string_view to_string(std::strong_ordering order) {
         return "greater";
     } else {
         assert(false);
+        return "internal error";
     }
 }
 

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -2,12 +2,13 @@
 #define BEMAN_CSTRING_VIEW_HPP
 
 #include <cassert>
+#include <cstddef>
 #include <compare>
+#include <format>
 #include <ranges>
 #include <stdexcept>
 #include <string_view>
 #include <string>
-#include <format>
 
 namespace beman {
     // [cstring.view.template], class template basic_cstring_view
@@ -113,9 +114,7 @@ namespace beman {
         constexpr basic_cstring_view(const charT* str, size_type len) : data_(str), size_(len) {
             assert(str[len] == charT());
         }
-        // https://github.com/llvm/llvm-project/issues/154577
-        // constexpr basic_cstring_view(nullptr_t) = delete;
-        constexpr basic_cstring_view(decltype(nullptr)) = delete;
+        constexpr basic_cstring_view(std::nullptr_t) = delete;
 
         // NOTE: Not part of proposal, just to make examples work since I can't add the conversion operator to
         // basic_string.

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -113,7 +113,9 @@ namespace beman {
         constexpr basic_cstring_view(const charT* str, size_type len) : data_(str), size_(len) {
             assert(str[len] == charT());
         }
-        basic_cstring_view(nullptr_t) = delete;
+        // https://github.com/llvm/llvm-project/issues/154577
+        // constexpr basic_cstring_view(nullptr_t) = delete;
+        constexpr basic_cstring_view(decltype(nullptr)) = delete;
 
         // NOTE: Not part of proposal, just to make examples work since I can't add the conversion operator to
         // basic_string.


### PR DESCRIPTION
## Description

Add workaround for LLVM bug https://github.com/llvm/llvm-project/issues/154577 . Add return statement in function that otherwise in release mode has a path that does not return.

## Related Issues

-

## Motivation and Context

Fixing the main builds

## Testing

Running the main builds on Clang/LLVM.

## Meta

- [ ] If all approvals are obtained and the PR is green, any Beman member can merge the PR.
