### PR TITLE
add unit test, fix substr to have two separate variants

### DIFF
--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -208,8 +208,11 @@ namespace beman {
             return std::basic_string_view<charT, traits>(*this).copy(s, n, pos);
         }
 
-        constexpr std::basic_string_view<charT, traits> substr(size_type pos = 0, size_type n = npos) const {
+        constexpr std::basic_string_view<charT, traits> substr(size_type pos, size_type n) const {
             return std::basic_string_view<charT, traits>(*this).substr(pos, n);
+        }
+        constexpr basic_cstring_view<charT, traits> substr(size_type pos = 0) const {
+            return { data_ + pos, size_ - pos };
         }
 
         constexpr int compare(std::basic_string_view<charT, traits> s) const noexcept {

--- a/tests/beman/cstring_view/cstring_view.test.cpp
+++ b/tests/beman/cstring_view/cstring_view.test.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include <beman/cstring_view/cstring_view.hpp>
+#include <string>
+#include <string_view>
+
+using namespace beman::literals;
+using namespace std::literals;
+
+TEST(StringView, ConstructionDestruction) {
+  std::string s = "hello";
+  beman::cstring_view h1 = "hello";
+  beman::cstring_view h2 = h1;
+
+  EXPECT_EQ(h1.c_str(), h2.c_str());
+  EXPECT_NE(h1.c_str(), s.c_str());
+  EXPECT_TRUE(h1 == h2);
+  EXPECT_TRUE(s == h1);
+  EXPECT_TRUE(h1.starts_with("he"));
+  EXPECT_TRUE(h1.ends_with("lo"));
+  EXPECT_TRUE(h1 == "hello");
+  EXPECT_TRUE(h1 == "hello"sv);
+  EXPECT_EQ(h1 <=> h1, std::strong_ordering::equal);
+  EXPECT_EQ(h1[0], 'h');
+  auto first = h1.substr(0, 3);
+  auto end = h1.substr(2);
+  EXPECT_TRUE((std::is_same_v<decltype(first), std::string_view>));
+  EXPECT_TRUE((std::is_same_v<decltype(end), beman::cstring_view>));
+  EXPECT_EQ(first, "hel");
+  EXPECT_EQ(end, "llo");
+}
+
+


### PR DESCRIPTION
## Description

Adds starter unit tests to validate at least some of the implementation. Ironically this immediately revealed a mismatch between spec and implementation, which I've fixed. More tests will come later, but adding this should at least let the unit-tests build on main run.

## Related Issues

- 

## Motivation and Context

Build on main fails due to zero tests. This increases it to non-zero and adds test coverage.

## Testing

These *are* the tests.

## Meta

- [ ] If all approvals are obtained and the PR is green, any Beman member can merge the PR.
