### PR TITLE
Add implicit conversion to std::string using operator std::string

### DIFF
--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -172,6 +172,10 @@ class basic_cstring_view {
         return std::basic_string_view<charT, traits>{data_, size_};
     }
 
+    constexpr operator std::basic_string<charT, traits>() const {
+        return std::basic_string<charT, traits>(data_, size_);
+    }
+
     // [cstring.view.modifiers], modifiers
     constexpr void remove_prefix(size_type n) {
         assert(n <= size());


### PR DESCRIPTION
Although it is not mentioned in the official RFC, there is no reason for not having an std::string conversion operator, the same kind as the one in std::string_view.

If strict adherence to P3655R2 is preferred, feel free to close this PR — I’m submitting it mainly for future reference.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
