### PR TITLE
Add constexpr attribute to operator std::basic_string_view

### DIFF
--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -168,7 +168,7 @@ class basic_cstring_view {
     constexpr const_pointer data() const noexcept { return data_; }
     constexpr const_pointer c_str() const noexcept { return data_; }
 
-    operator std::basic_string_view<charT, traits>() const noexcept {
+    constexpr operator std::basic_string_view<charT, traits>() const noexcept {
         return std::basic_string_view<charT, traits>{data_, size_};
     }
 


### PR DESCRIPTION
This PR makes the operator constexpr (available since C++20). While not explicitly mentioned in the RFC, there appears to be no reason to prevent compile-time usage, and this matches the behavior of similar standard library operators.

If strict adherence to P3655R2 is preferred, feel free to close this PR — I’m submitting it mainly for future reference.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
