### PR TITLE
Change implementation to follow spec

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,7 +104,7 @@ jobs:
                 { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 },
-                { "cxxversions": ["c++20", "c++17"],
+                { "cxxversions": ["c++20"],
                   "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -49,14 +49,14 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
             { "versions": ["14", "13"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -64,7 +64,7 @@ jobs:
             {
               "versions": ["12", "11"],
               "tests": [
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -83,7 +83,7 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -92,7 +92,7 @@ jobs:
             },
             { "versions": ["21", "20", "19"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -101,7 +101,7 @@ jobs:
             },
             { "versions": ["18", "17"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 },
                 { "cxxversions": ["c++20", "c++17"],
@@ -113,7 +113,7 @@ jobs:
           "appleclang": [
             { "versions": ["latest"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -134,7 +134,86 @@ jobs:
           ]
         }
 
+  build-and-test-cpp17:
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-build-and-test.yml@1.5.0
+    with:
+      matrix_config: >
+        {
+          "gcc": [
+            { "versions": ["15"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++17"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            },
+            { "versions": ["14", "13"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++17"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            },
+            {
+              "versions": ["12", "11"],
+              "tests": [
+                { "cxxversions": ["c++23", "c++17"],
+                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            }
+          ],
+          "clang": [
+            { "versions": ["22"],
+              "tests": [
+                { "cxxversions": ["c++23", "c++17"],
+                  "tests": [
+                    {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}
+                  ]
+                }
+              ]
+            },
+            { "versions": ["21", "20", "19"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++17"],
+                  "tests": [
+                    {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}
+                  ]
+                }
+              ]
+            },
+            { "versions": ["18", "17"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++17"],
+                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                },
+                { "cxxversions": ["c++20", "c++17"],
+                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            }
+          ],
+          "appleclang": [
+            { "versions": ["latest"],
+              "tests": [
+                { "cxxversions": ["c++26", "c++17"],
+                  "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            }
+          ],
+          "msvc": [
+            { "versions": ["latest"],
+              "tests": [
+                { "cxxversions": ["c++23", "c++17"],
+                  "tests": [{ "stdlibs": ["stl"], "tests": ["Release.-DBEMAN_CSTRING_VIEW_CPP17_MODE=on"]}]
+                }
+              ]
+            }
+          ]
+        }
+
   create-issue-when-fault:
-    needs: [preset-test, build-and-test]
+    needs: [preset-test, build-and-test, build-and-test-cpp17]
     if: failure() && github.event_name == 'schedule'
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,7 @@ add_subdirectory(include/beman/cstring_view)
 beman_install_library(beman.cstring_view TARGETS beman.cstring_view)
 
 if(BEMAN_CSTRING_VIEW_CPP17_MODE)
-    target_compile_options(
-        beman.cstring_view
-        INTERFACE -DUSE_CPP17_VARIANT
-    )
+    target_compile_options(beman.cstring_view INTERFACE -DUSE_CPP17_VARIANT)
 endif()
 
 if(BEMAN_CSTRING_VIEW_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ option(
     ${PROJECT_IS_TOP_LEVEL}
 )
 
+# [CMAKE.CPP17_MODE]
+option(
+    BEMAN_CSTRING_VIEW_CPP17_MODE
+    "Use the C++17 compatible implementation. Default: OFF. Values: { ON, OFF }."
+    OFF
+)
+
 # [CMAKE.SKIP_EXAMPLES]
 option(
     BEMAN_CSTRING_VIEW_BUILD_EXAMPLES
@@ -43,6 +50,13 @@ set_target_properties(
 add_subdirectory(include/beman/cstring_view)
 
 beman_install_library(beman.cstring_view TARGETS beman.cstring_view)
+
+if(BEMAN_CSTRING_VIEW_CPP17_MODE)
+    target_compile_options(
+        beman.cstring_view
+        INTERFACE -DUSE_CPP17_VARIANT
+    )
+endif()
 
 if(BEMAN_CSTRING_VIEW_BUILD_TESTS)
     enable_testing()

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -18,6 +18,11 @@
 
 namespace beman {
 
+#if __cpp_concepts >= 201907L
+template<typename T>
+  concept cstring_like = requires(const T & t) { { t.c_str() } -> std::same_as<const T::value_type*> };
+#endif
+
 // [cstring.view.template], class template basic_cstring_view
 template <class charT, class traits = std::char_traits<charT>>
 class basic_cstring_view; // partially freestanding
@@ -109,11 +114,18 @@ class basic_cstring_view {
     }
     constexpr basic_cstring_view(std::nullptr_t) = delete;
 
-    // NOTE: Not part of proposal, just to make examples work since I can't add the conversion operator to
-    // basic_string.
-    template <typename Traits, typename Allocator>
-    constexpr basic_cstring_view(const std::basic_string<charT, Traits, Allocator>& str)
-        : basic_cstring_view(str.c_str(), str.size()) {}
+    template <typename R
+#if __cpp_concepts < 201907L
+    // Just pretend this is doing the concept match that the paper proposes
+    , typename = decltype((*(std::decay_t<R>*)0).c_str())
+#endif
+    >
+    constexpr basic_cstring_view(
+#if __cpp_concepts >= 201907L
+                                 cstring_like
+#endif
+                                              R&& r)
+    : basic_cstring_view(r.c_str(), r.size()) {}
 
     // [cstring.view.iterators], iterator support
     constexpr const_iterator         begin() const noexcept { return data_; }

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -121,7 +121,7 @@ class basic_cstring_view {
     template <typename R, typename = decltype((*(std::decay_t<R>*)0).c_str())>
     constexpr basic_cstring_view(R&& r)
 #else
-    constexpr basic_cstring_view(cstring_like auto r)
+    constexpr basic_cstring_view(cstring_like auto& r)
 #endif
         : basic_cstring_view(r.c_str(), r.size()) {
     }

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -18,7 +18,8 @@
 
 namespace beman {
 
-#if __cpp_concepts >= 201907L
+#if !defined(USE_CPP17_VARIANT)
+static_assert(__cpp_concepts >= 201907L);
 template <typename T>
 concept cstring_like = requires(const T& t) {
     { t.c_str() } -> std::same_as<const typename T::value_type*>;
@@ -116,11 +117,12 @@ class basic_cstring_view {
     }
     constexpr basic_cstring_view(std::nullptr_t) = delete;
 
-#if __cpp_concepts < 201907L
+#if defined(USE_CPP17_VARIANT)
     // Just pretend this is doing the concept match that the paper proposes
     template <typename R, typename = decltype((*(std::decay_t<R>*)0).c_str())>
     constexpr basic_cstring_view(R&& r)
 #else
+    static_assert(__cpp_concepts >= 201907L);
     constexpr basic_cstring_view(const cstring_like auto& r)
 #endif
         : basic_cstring_view(r.c_str(), r.size()) {

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -121,7 +121,7 @@ class basic_cstring_view {
     template <typename R, typename = decltype((*(std::decay_t<R>*)0).c_str())>
     constexpr basic_cstring_view(R&& r)
 #else
-    constexpr basic_cstring_view(cstring_like auto& r)
+    constexpr basic_cstring_view(cstring_like auto const& r)
 #endif
         : basic_cstring_view(r.c_str(), r.size()) {
     }

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -121,7 +121,7 @@ class basic_cstring_view {
     template <typename R, typename = decltype((*(std::decay_t<R>*)0).c_str())>
     constexpr basic_cstring_view(R&& r)
 #else
-    constexpr basic_cstring_view(cstring_like auto const& r)
+    constexpr basic_cstring_view(const cstring_like auto& r)
 #endif
         : basic_cstring_view(r.c_str(), r.size()) {
     }

--- a/include/beman/cstring_view/cstring_view.hpp
+++ b/include/beman/cstring_view/cstring_view.hpp
@@ -19,8 +19,10 @@
 namespace beman {
 
 #if __cpp_concepts >= 201907L
-template<typename T>
-  concept cstring_like = requires(const T & t) { { t.c_str() } -> std::same_as<const T::value_type*> };
+template <typename T>
+concept cstring_like = requires(const T& t) {
+    { t.c_str() } -> std::same_as<const typename T::value_type*>;
+};
 #endif
 
 // [cstring.view.template], class template basic_cstring_view
@@ -114,18 +116,15 @@ class basic_cstring_view {
     }
     constexpr basic_cstring_view(std::nullptr_t) = delete;
 
-    template <typename R
 #if __cpp_concepts < 201907L
     // Just pretend this is doing the concept match that the paper proposes
-    , typename = decltype((*(std::decay_t<R>*)0).c_str())
+    template <typename R, typename = decltype((*(std::decay_t<R>*)0).c_str())>
+    constexpr basic_cstring_view(R&& r)
+#else
+    constexpr basic_cstring_view(cstring_like auto r)
 #endif
-    >
-    constexpr basic_cstring_view(
-#if __cpp_concepts >= 201907L
-                                 cstring_like
-#endif
-                                              R&& r)
-    : basic_cstring_view(r.c_str(), r.size()) {}
+        : basic_cstring_view(r.c_str(), r.size()) {
+    }
 
     // [cstring.view.iterators], iterator support
     constexpr const_iterator         begin() const noexcept { return data_; }


### PR DESCRIPTION
This changes the implementation to use the concept-constrained range constructor as per P3655 for C++20+, and an equivalent implementation for C++17. As this is a bifurcation there's cmake stuff to make that work.